### PR TITLE
Each plugin gets its own processing buffer

### DIFF
--- a/source/plugin/Plugin.c
+++ b/source/plugin/Plugin.c
@@ -133,6 +133,10 @@ Plugin _newPlugin(PluginInterfaceType interfaceType, PluginType pluginType) {
   plugin->pluginName = newCharString();
   plugin->pluginLocation = newCharString();
   plugin->pluginAbsolutePath = newCharString();
+  // Initialize processing buffer with the currently known channel count, this
+  // may be expanded to the maximum number of needed channels when the plugin
+  // is opened and its I/O configuration is known.
+  plugin->processingBuffer = newSampleBuffer(getNumChannels(), getBlocksize());
 
   return plugin;
 }
@@ -146,6 +150,7 @@ void freePlugin(Plugin self) {
     freeCharString(self->pluginName);
     freeCharString(self->pluginLocation);
     freeCharString(self->pluginAbsolutePath);
+    freeSampleBuffer(self->processingBuffer);
     free(self);
   }
 }

--- a/source/plugin/Plugin.h
+++ b/source/plugin/Plugin.h
@@ -124,6 +124,7 @@ typedef struct {
   CharString pluginName;
   CharString pluginLocation;
   CharString pluginAbsolutePath;
+  SampleBuffer processingBuffer;
 
   PluginOpenFunc openPlugin;
   PluginDisplayInfoFunc displayInfo;

--- a/source/plugin/PluginVst2x.h
+++ b/source/plugin/PluginVst2x.h
@@ -49,6 +49,18 @@ void listAvailablePluginsVst2x(const CharString pluginRoot);
 Plugin newPluginVst2x(const CharString pluginName, const CharString pluginRoot);
 
 /**
+ * Set the I/O configuration of a VST 2.x plugin. Most plugins should know this
+ * value when they are opened, however some plugins may make a callback to the
+ * host dispatcher informing them that their I/O configuration has changed. If
+ * that should happen, then this function can be called to resize the plugin's
+ * internal processing buffer to reflect the new channel count.
+ * @param self
+ * @param numInputs Number of input channels
+ * @param numOutputs Number of output channels
+ */
+void pluginVst2xSetIOConfig(Plugin self, const unsigned int numInputs, const unsigned int numOutputs);
+
+/**
  * Get the VST2.x unique ID
  * @param self
  * @return Unique ID, or 0 if not known (yes, this can happen)


### PR DESCRIPTION
This should hopefully resolve a number of channel-conversion related bugs,
such as #156 and #164.
