### PR TITLE
Using same type for byteRate as is passed to fwrite. Fixes #158

### DIFF
--- a/source/io/SampleSourceWave.c
+++ b/source/io/SampleSourceWave.c
@@ -154,7 +154,7 @@ static boolByte _readWaveFileInfo(const char* filename, SampleSourcePcmData extr
 static boolByte _writeWaveFileInfo(SampleSourcePcmData extraData) {
   RiffChunk chunk = newRiffChunk();
   unsigned short audioFormat = 1;
-  unsigned short byteRate = (unsigned short)(extraData->sampleRate * extraData->numChannels * extraData->bitsPerSample / 8);
+  unsigned int byteRate = (unsigned int)(extraData->sampleRate * extraData->numChannels * extraData->bitsPerSample / 8);
   unsigned short blockAlign = extraData->numChannels * extraData->bitsPerSample / 8;
   unsigned int extraParams = 0;
 


### PR DESCRIPTION
A friend of mine (@ncb-nota) discovered that BitRate was not displayed in Microsoft File Explorer, that hinted a problem which then was confirmed by pure code-review. It turns out that fixing this resolves #158. :smile: 
