### PR TITLE
Assign result to var before freeing memory

### DIFF
--- a/source/plugin/PluginVst2x.cpp
+++ b/source/plugin/PluginVst2x.cpp
@@ -233,8 +233,9 @@ static CharString _getVst2xPluginLocation(const CharString pluginName, const Cha
   while(iterator != NULL) {
     CharString searchLocation = (CharString)(iterator->item);
     if(_doesVst2xPluginExistAtLocation(pluginName, searchLocation)) {
+      CharString result = newCharStringWithCString(searchLocation->data);
       freeLinkedListAndItems(pluginLocations, (LinkedListFreeItemFunc)freeCharString);
-      return newCharStringWithCString(searchLocation->data);
+      return result;
     }
     iterator = (LinkedListIterator)iterator->nextItem;
   }


### PR DESCRIPTION
This patches a segfault occurring when trying to run newCharStringWithCString on searchLocation->data.
