### PR TITLE
Ensure platform_bits case is same in cmake files

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -27,11 +27,11 @@ elseif(MSVC)
   # Visual Studio we need to generate two separate out-of-source build dirs,
   # one for each architecture.
   # TODO: There must be some way to fix this, Juce manages to do it...
-  if(${platform_bits} EQUAL 32)
+  if(${PLATFORM_BITS} EQUAL 32)
     add_executable(mrswatson ${mrswatsonmain_SOURCES} ${mrswatsonmain_HEADERS})
     set_target_properties(mrswatson PROPERTIES COMPILE_FLAGS "/D WIN32=1")
     target_link_libraries(mrswatson mrswatsoncore)
-  elseif(${platform_bits} EQUAL 64)
+  elseif(${PLATFORM_BITS} EQUAL 64)
     add_executable(mrswatson64 ${mrswatsonmain_SOURCES} ${mrswatsonmain_HEADERS})
     set_target_properties(mrswatson64 PROPERTIES COMPILE_FLAGS "/MACHINE:X64 /D WIN64=1")
     target_link_libraries(mrswatson64 mrswatsoncore64)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -23,10 +23,10 @@ elseif(MSVC)
   # Visual Studio we need to generate two separate out-of-source build dirs,
   # one for each architecture.
   # TODO: There must be some way to fix this, Juce manages to do it...
-  if(${platform_bits} EQUAL 32)
+  if(${PLATFORM_BITS} EQUAL 32)
     add_library(mrswatsoncore ${mrswatsoncore_SOURCES} ${mrswatsoncore_HEADERS})
     set_target_properties(mrswatsoncore PROPERTIES COMPILE_FLAGS "/D WIN32=1")
-  elseif(${platform_bits} EQUAL 64)
+  elseif(${PLATFORM_BITS} EQUAL 64)
     add_library(mrswatsoncore64 ${mrswatsoncore_SOURCES} ${mrswatsoncore_HEADERS})
     set_target_properties(mrswatsoncore64 PROPERTIES COMPILE_FLAGS "/MACHINE:X64 /D WIN64=1")
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,11 +27,11 @@ elseif(MSVC)
   # Visual Studio we need to generate two separate out-of-source build dirs,
   # one for each architecture.
   # TODO: There must be some way to fix this, Juce manages to do it...
-  if(${platform_bits} EQUAL 32)
+  if(${PLATFORM_BITS} EQUAL 32)
     add_executable(mrswatsontest ${mrswatsontest_SOURCES} ${mrswatsontest_HEADERS})
     set_target_properties(mrswatsontest PROPERTIES COMPILE_FLAGS "/D WIN32=1")
     target_link_libraries(mrswatsontest mrswatsoncore)
-  elseif(${platform_bits} EQUAL 64)
+  elseif(${PLATFORM_BITS} EQUAL 64)
     add_executable(mrswatsontest64 ${mrswatsontest_SOURCES} ${mrswatsontest_HEADERS})
     set_target_properties(mrswatsontest64 PROPERTIES COMPILE_FLAGS "/MACHINE:X64 /D WIN64=1")
     target_link_libraries(mrswatsontest64 mrswatsoncore64)


### PR DESCRIPTION
Cmake was failing on Windows due to PLATFORM_BITS case being inconsistent across cmake files. Changed them all to be the same case as the definition.
