### PR TITLE
Issue 209: WAV header writing: Sample rate is invalid (zero)

### DIFF
--- a/source/io/SampleSourceWave.c
+++ b/source/io/SampleSourceWave.c
@@ -211,7 +211,8 @@ static boolByte _writeWaveFileInfo(SampleSourcePcmData extraData)
         return false;
     }
 
-    if (fwrite(&(extraData->sampleRate), sizeof(unsigned int), 1, extraData->fileHandle) != 1) {
+    unsigned int sampleRateAsUInt = (unsigned int)extraData->sampleRate;
+    if (fwrite(&(sampleRateAsUInt), sizeof(unsigned int), 1, extraData->fileHandle) != 1) {
         logError("Could not write sample rate");
         freeRiffChunk(chunk);
         return false;


### PR DESCRIPTION
This fix is to convert the sample rate to the right data type (unsigned int) before writing it to the wav file.

NOTE: The original pull request had the wrong indentation (tabs instead of spaces). I fixed it now, I hope you are able to see the updated commit.

Sorry for the multiple pull request edits.