### PR TITLE
_snprintf fix for Windows build

### DIFF
--- a/source/base/Types.h
+++ b/source/base/Types.h
@@ -67,11 +67,14 @@ typedef unsigned char byte;
 // Substitutes for POSIX functions not found on Windows
 #define strcasecmp _stricmp
 #define strdup _strdup
-#define unlink _unlink
-#define snprintf _snprintf
 #define isatty _isatty
 #define chdir _chdir
 #define unlink _unlink
+
+#if _MSC_VER < 1900 
+#define snprintf _snprintf
+#endif
+
 #endif
 
 // LibraryHandle definition


### PR DESCRIPTION
Issue #222 
Tiny fix required for building MrsWatson with Microsoft Visual Studio 14 (2015) or higher.

Also saw a duplicate #define for _unlink which I presumed was unnecessary.
